### PR TITLE
fix: work with git's GIT_DIR

### DIFF
--- a/lib/dotgitconfig.js
+++ b/lib/dotgitconfig.js
@@ -5,12 +5,12 @@ const ini = require('ini');
 const path = require('path');
 
 const format = data => {
-  var res = {};
+  const res = {};
   Object.keys(data).forEach(k => {
-    if (!!~k.indexOf('"')) {
-      var arr = k.split('"');
-      var mainkey = arr.shift().trim();
-      var childkey = arr.shift().trim();
+    if (~k.indexOf('"')) {
+      const arr = k.split('"');
+      const mainkey = arr.shift().trim();
+      const childkey = arr.shift().trim();
 
       if (!res[mainkey]) {
         res[mainkey] = {};
@@ -24,7 +24,12 @@ const format = data => {
 };
 
 module.exports = (dir, cb) => {
-  const filePath = path.resolve(process.env.GIT_DIR || dir, '.git', 'config');
+  let gitDir = process.env.GIT_DIR || dir;
+  // makeup .git
+  if (!gitDir.endsWith('/.git')) {
+    gitDir = path.resolve(gitDir, '.git');
+  }
+  const filePath = path.resolve(gitDir, 'config');
   const isExisted = fs.existsSync(filePath) && fs.statSync(filePath).isFile();
 
   if (!isExisted) {


### PR DESCRIPTION
适配git的GIT_DIR环境变量 应指.git目录而非工程目录
  // yhn@yhnMBP LCL % export GIT_DIR=/Users/yhn/github/LCL
  // yhn@yhnMBP LCL % git pull
  // fatal: not a git repository: '/Users/yhn/github/LCL'
  // yhn@yhnMBP LCL % export GIT_DIR=/Users/yhn/github/LCL/.git
  // yhn@yhnMBP LCL % git pull
  // Already up to date.